### PR TITLE
jnr-a64asm: license is updated in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 
   <licenses>
     <license>
-      <name>MIT License</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Apache 2.0 license is used to align with all jnr project

Signed-off-by: ossdev <ossdev@puresoftware.com>